### PR TITLE
1254: Fixed "add one more" for book ref. fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ See [keep a changelog] for information about writing changes to this log.
 
 ## [Unreleased]
 
+* Fixed "Add one more" for book ref. fields to the open platform.
+
 ## [4.0.1] 2023-10-05
 
 * Added pull request template

--- a/web/modules/custom/lit_open_platform/lit_open_platform.module
+++ b/web/modules/custom/lit_open_platform/lit_open_platform.module
@@ -41,7 +41,13 @@ function lit_open_platform_field_widget_complete_form_alter(&$field_widget_compl
       $target_bundles = $settings['handler_settings']['target_bundles'];
 
       if (in_array('book', $target_bundles)) {
-        $field_widget_complete_form['widget'][0]['target_id']['#selection_handler'] = 'lit:node';
+        // Change selection handler for each widget (even for "Add one more"
+        // fields)
+        foreach ($field_widget_complete_form['widget'] as &$widget) {
+          if (is_array($widget) && isset($widget['target_id']['#selection_handler'])) {
+            $widget['target_id']['#selection_handler'] = 'lit:node';
+          }
+        }
       }
     }
   }

--- a/web/modules/custom/lit_open_platform/src/Form/LitBlockContentForm.php
+++ b/web/modules/custom/lit_open_platform/src/Form/LitBlockContentForm.php
@@ -100,7 +100,7 @@ class LitBlockContentForm extends ContentEntityForm implements ContentEntityForm
           continue;
         }
 
-        // Create book if does not exist.
+        // Create book if it does not exist.
         $node = Node::create($book);
 
         if ($node->save()) {

--- a/web/modules/custom/lit_open_platform/src/Form/LitNodeForm.php
+++ b/web/modules/custom/lit_open_platform/src/Form/LitNodeForm.php
@@ -51,7 +51,7 @@ class LitNodeForm extends ContentEntityForm implements ContentEntityFormInterfac
       // Get the open platform pids.
       $pids = $this->getPids($values[$field]);
 
-      if ($pids && $nids = $this->createBooksFromPids($pids)) {
+      if (!empty($pids) && $nids = $this->createBooksFromPids($pids)) {
         foreach ($nids as $index => $nid) {
           $values[$field][$index]['target_id'] = $nid;
         }
@@ -155,7 +155,7 @@ class LitNodeForm extends ContentEntityForm implements ContentEntityFormInterfac
     $pids = [];
 
     foreach ($values as $i => $value) {
-      if (is_array($value) && $value['target_id']) {
+      if (is_array($value) && isset($value['target_id'])) {
         if (is_int($i) && preg_match('/^\d+-\w+:(\d|_)+$/', $value['target_id'])) {
           $pids[$i] = $value['target_id'];
         }


### PR DESCRIPTION
#### Link to ticket

https://jira.itkdev.dk/browse/SUPP0RT-1254

#### Description

Fixed "add one more" for book ref. fields

#### Screenshot of the result

![Screenshot from 2023-10-05 20-35-02](https://github.com/litteratursiden/litteratursiden/assets/111397/b368c072-b4dd-4e09-a967-9ec8bb13701c)

#### Checklist

- [ ] My code passes our static analysis suite.
- [ ] My code passes our continuous integration process.

If your code does not pass all the requirements on the checklist you have to add a comment explaining why this change
should be exempt from the list.

#### Additional comments or questions

N/A