### PR TITLE
LIT-376: Topics infinitescroll patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ See [keep a changelog] for information about writing changes to this log.
 
 * Fixed "Add one more" for book ref. fields to the open platform.
 * Update config of sitemap scope, to only include content types: temaer, boglister, artiker.
+* Fixed an issue with viewsreference interfering with infinitescroll.
 
 ## [4.0.1] 2023-10-05
 

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,14 @@
         },
         {
             "type": "composer",
-            "url": "https://packages.drupal.org/8"
+            "url": "https://packages.drupal.org/8",
+            "exclude": [
+                "drupal/viewsreference"
+            ]
+        },
+        {
+            "type": "git",
+            "url": "https://git.drupalcode.org/issue/viewsreference-3364798"
         },
         {
           "type": "composer",
@@ -142,7 +149,7 @@
         "drupal/view_unpublished": "^1.1",
         "drupal/views_infinite_scroll": "^2.0",
         "drupal/views_show_more": "^2.0",
-        "drupal/viewsreference": "^2.0@beta",
+        "drupal/viewsreference": "dev-3364798-views-reference-is",
         "drupal/xmlsitemap": "^1.4",
         "drush/drush": "^12.0",
         "ganlanyuan/tiny-slider": "master",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "58494cf4e4d5870dc4b3ab43e63901d5",
+    "content-hash": "c189c8dfc70ba00a96a9d51ee16d5f4f",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -5191,56 +5191,18 @@
         },
         {
             "name": "drupal/viewsreference",
-            "version": "2.0.0-beta4",
+            "version": "dev-3364798-views-reference-is",
             "source": {
                 "type": "git",
-                "url": "https://git.drupalcode.org/project/viewsreference.git",
-                "reference": "8.x-2.0-beta4"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/viewsreference-8.x-2.0-beta4.zip",
-                "reference": "8.x-2.0-beta4",
-                "shasum": "913d6c77d73a9aa475b695a069ec5258569ddb07"
-            },
-            "require": {
-                "drupal/core": "^9.3 || ^10"
+                "url": "https://git.drupalcode.org/issue/viewsreference-3364798",
+                "reference": "ba53ef16af30c33a07ee0c15f9f4c8ad81f540b2"
             },
             "conflict": {
                 "drupal/viewsreferennce": "*"
             },
             "type": "drupal-module",
-            "extra": {
-                "drupal": {
-                    "version": "8.x-2.0-beta4",
-                    "datestamp": "1664821610",
-                    "security-coverage": {
-                        "status": "not-covered",
-                        "message": "Beta releases are not covered by Drupal security advisories."
-                    }
-                }
-            },
-            "notification-url": "https://packages.drupal.org/8/downloads",
             "license": [
                 "GPL-2.0-or-later"
-            ],
-            "authors": [
-                {
-                    "name": "jasonawant",
-                    "homepage": "https://www.drupal.org/user/589890"
-                },
-                {
-                    "name": "joekers",
-                    "homepage": "https://www.drupal.org/user/2229066"
-                },
-                {
-                    "name": "NewZeal",
-                    "homepage": "https://www.drupal.org/user/93571"
-                },
-                {
-                    "name": "seanB",
-                    "homepage": "https://www.drupal.org/user/545912"
-                }
             ],
             "description": "Views reference",
             "homepage": "http://drupal.org/project/viewsreference",
@@ -5248,9 +5210,10 @@
                 "Drupal"
             ],
             "support": {
-                "source": "https://git.drupalcode.org/project/viewsreference",
-                "issues": "https://www.drupal.org/project/issues/viewsreference"
-            }
+                "issues": "https://www.drupal.org/project/issues/viewsreference",
+                "source": "https://git.drupalcode.org/project/viewsreference"
+            },
+            "time": "2023-06-05T08:38:40+00:00"
         },
         {
             "name": "drupal/xmlsitemap",
@@ -15337,7 +15300,7 @@
         "drupal/purge": 10,
         "drupal/rest_views": 20,
         "drupal/s3fs": 15,
-        "drupal/viewsreference": 10
+        "drupal/viewsreference": 20
     },
     "prefer-stable": true,
     "prefer-lowest": false,
@@ -15345,5 +15308,5 @@
         "php": "^8.1"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
#### Link to ticket

https://jira.itkdev.dk/browse/LIT-376

#### Description

Applies a patch to viewsreference that interferes with the way infinitescroll loads additional content on the topics-page (temaer).

#### Screenshot of the result

N/A

#### Checklist

- [ ] My code passes our static analysis suite.
- [ ] My code passes our continuous integration process.

If your code does not pass all the requirements on the checklist you have to add a comment explaining why this change
should be exempt from the list.

#### Additional comments or questions

If you have any further comments or questions for the reviewer please add them here.
